### PR TITLE
client_id typo

### DIFF
--- a/lib/mqtt/client.rb
+++ b/lib/mqtt/client.rb
@@ -117,7 +117,7 @@ class MQTT::Client
   def connect(clientid=nil)
     if !clientid.nil?
       @client_id = clientid
-    elsif @clientid.nil?
+    elsif @client_id.nil?
       @client_id = MQTT::Client.generate_client_id
       @clean_session = true
     end


### PR DESCRIPTION
This fixes the bug that client_id is nil when you try to define it in this way:

MQTT::Client.connect(:remote_host => broker, :remote_port => port, :client_id => ci) do |client|
  ...
end
