### PR TITLE
Avoid 'warning: assigned but unused variable' warn

### DIFF
--- a/lib/mqtt/packet.rb
+++ b/lib/mqtt/packet.rb
@@ -697,7 +697,7 @@ module MQTT
       end
 
       def inspect
-        str = "\#<#{self.class}: 0x%2.2X, %s>" % [
+        _str = "\#<#{self.class}: 0x%2.2X, %s>" % [
           message_id,
           topics.map {|t| "'#{t[0]}':#{t[1]}"}.join(', ')
         ]
@@ -793,7 +793,7 @@ module MQTT
       end
 
       def inspect
-        str = "\#<#{self.class}: 0x%2.2X, %s>" % [
+        _str = "\#<#{self.class}: 0x%2.2X, %s>" % [
           message_id,
           topics.map {|t| "'#{t}'"}.join(', ')
         ]


### PR DESCRIPTION
When $VERBOSE is true ruby will log error for unused variables, this
error can be suppressed by prefixing variable by '_', or having variable
named '_', which is canonical signal for 'unnecessary'

(refer to commit c9528f6a9e3157b349d3d81d20b9b4047ee9ff63 as well)
