### PR TITLE
Added TLS support

### DIFF
--- a/spec/mqtt_client_spec.rb
+++ b/spec/mqtt_client_spec.rb
@@ -126,6 +126,23 @@ describe MQTT::Client do
       @client.clean_session.should be_true
     end
 
+    it "should use TLS if certificate and key are given" do
+      context = double "SSLContext", :cert= => nil, :key= => nil
+      socket = double "SSLSocket", :sync_close= => true, :write => true, :connect => true
+      File.stub(:open).and_return("-----BEGIN CERTIFICATE-----")
+
+      OpenSSL::SSL::SSLContext.stub(:new).and_return(context)
+      OpenSSL::SSL::SSLSocket.stub(:new).and_return(socket)
+
+      OpenSSL::X509::Certificate.stub(:new)
+      OpenSSL::PKey::RSA.stub(:new)
+      socket.should_receive(:connect)
+
+      @client.tls_certfile = "client.crt"
+      @client.tls_keyfile = "client.key"
+      @client.connect
+    end
+
     context "with a last will and testament set" do
       before(:each) do
         @client.set_will('topic', 'hello', retain=false, qos=1)


### PR DESCRIPTION
This adds support for TLS. Simply drop in a client certificate and a keyfile (+ optionally a ca certificate):

``` ruby
c = MQTT::Client.connect({
  remote_host:  "127.0.0.1",
  tls_cafile:   "./certs/rootCA.crt",
  tls_certfile: "./certs/client.crt",
  tls_keyfile:  "./certs/client.key"
})
```
