### PR TITLE
Fix error on publish with frozen payload.

### DIFF
--- a/lib/mqtt/packet.rb
+++ b/lib/mqtt/packet.rb
@@ -368,7 +368,7 @@ module MQTT
         end
         body += encode_string(@topic)
         body += encode_short(@id) unless qos == 0
-        body += payload.to_s.force_encoding('ASCII-8BIT')
+        body += payload.to_s.dup.force_encoding('ASCII-8BIT')
         return body
       end
 

--- a/spec/mqtt_client_spec.rb
+++ b/spec/mqtt_client_spec.rb
@@ -538,6 +538,11 @@ describe MQTT::Client do
       expect(socket.string).to eq("\x30\x06\x00\x04test")
     end
 
+    it "should write a valid PUBLISH packet with frozen payload" do
+      client.publish('topic', 'payload'.freeze, false, 0)
+      expect(socket.string).to eq("\x30\x0e\x00\x05topicpayload")
+    end
+
     it "should throw an ArgumentError exception, if the topic is nil" do
       expect {
         client.publish(nil)


### PR DESCRIPTION
MQTT::Client#publish with frozen String as payload raise RuntimeError "can't modify frozen String".

```
client.publish("topic", "payload".freeze, false, 0) # => RuntimeError: can't modify frozen String
```

String#force_encoding change the receiver String object itself, and MQTT::Packet#encode_body can call force_encoding to argument passed to MQTT::Client#publish.