### PR TITLE
Add 'name' stub to String patches. Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .bundle
 .ruby-version
+.ruby-gemset
 .yardoc
 *.gem
 coverage

--- a/lib/mqtt/patches/string_encoding.rb
+++ b/lib/mqtt/patches/string_encoding.rb
@@ -24,6 +24,10 @@ class Encoding
   def to_s
     @name
   end
+  
+  def name
+    @name
+  end
 
   UTF_8 = Encoding.new("UTF-8")
   ASCII_8BIT = Encoding.new("ASCII-8BIT")


### PR DESCRIPTION
Hi, I made a small fix to String patches adding 'name' method because I found an issue with another gem (bunny) that I'm using and that was throwing an exception because of the missing method.
Hope this helps.