### PR TITLE
Update FakeServer and integration test to avoid timeout on waiting for puback packet

### DIFF
--- a/spec/fake_server.rb
+++ b/spec/fake_server.rb
@@ -100,6 +100,11 @@ class MQTT::FakeServer
         when MQTT::Packet::Publish
           client.write packet
           @last_publish = packet
+
+          if packet.qos > 0
+            puback = MQTT::Packet::Puback.new(:id => 1)
+            client.write puback
+          end
         when MQTT::Packet::Subscribe
           client.write MQTT::Packet::Suback.new(
             :id => packet.id,

--- a/spec/zz_client_integration_spec.rb
+++ b/spec/zz_client_integration_spec.rb
@@ -24,9 +24,13 @@ describe "a client talking to a server" do
   end
 
   context "connecting and publishing a packet" do
-    def connect_and_publish
+    def connect_and_publish(options = {})
       @client.connect
-      @client.publish('test', 'foobar')
+
+      retain = options.fetch(:retain) { false }
+      qos = options.fetch(:qos) { 0 }
+
+      @client.publish('test', 'foobar', retain, qos)
       @client.disconnect
       @server.thread.join(1)
     end
@@ -49,6 +53,13 @@ describe "a client talking to a server" do
     it "the server should not report any errors" do
       connect_and_publish
       expect(@error_log.string).to be_empty
+    end
+
+    context "with qos > 0" do
+      it "the server should have received a packet without timeout" do
+        connect_and_publish(:qos => 1)
+        expect(@server.last_publish).not_to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
I'm using `MQTT::FakeServer` in my integration test and it failed when we publish messages with qos > 0.  Then I figured out this problem :)