### PR TITLE
Don't keepalive ping if disconnected

### DIFF
--- a/lib/mqtt/client.rb
+++ b/lib/mqtt/client.rb
@@ -500,7 +500,7 @@ private
   end
 
   def keep_alive!
-    if @keep_alive > 0
+    if @keep_alive > 0 && connected?
       response_timeout = (@keep_alive * 1.5).ceil
       if Time.now >= @last_ping_request + @keep_alive
         packet = MQTT::Packet::Pingreq.new
@@ -530,7 +530,7 @@ private
 
       # Check the return code
       if packet.return_code != 0x00
-        # 3.2.2.3 If a server sends a CONNACK packet containing a non-zero 
+        # 3.2.2.3 If a server sends a CONNACK packet containing a non-zero
         # return code it MUST then close the Network Connection
         @socket.close
         raise MQTT::ProtocolException.new(packet.return_msg)

--- a/spec/mqtt_client_spec.rb
+++ b/spec/mqtt_client_spec.rb
@@ -175,7 +175,7 @@ describe MQTT::Client do
       expect(client.ssl_context.cert).to be_a(OpenSSL::X509::Certificate)
     end
   end
-    
+
   describe "setting a client private key file path" do
     it "should add a certificate to the SSL context" do
       expect(client.ssl_context.key).to be_nil
@@ -603,7 +603,7 @@ describe MQTT::Client do
     it "correctly assigns consecutive ids to packets with QoS 1" do
       inject_puback(1)
       inject_puback(2)
-      
+
       expect(client).to receive(:send_packet) { |packet| expect(packet.id).to eq(1) }
       client.publish "topic", "message", false, 1
       expect(client).to receive(:send_packet) { |packet| expect(packet.id).to eq(2) }
@@ -852,6 +852,13 @@ describe MQTT::Client do
         MQTT::ProtocolException,
         /No Ping Response received for \d+ seconds/
       )
+    end
+
+    it "should not raise an exception if no ping response received and client is disconnected" do
+      client.instance_variable_set('@last_ping_request', Time.now)
+      client.instance_variable_set('@last_ping_response', Time.at(0))
+      client.disconnect(false)
+      client.send('keep_alive!')
     end
   end
 


### PR DESCRIPTION
I'm not 100% sure this is the correct solution, but it solved a problem for me so I thought I'd at least share it and see if it's useful for you.

The problem I'm trying to solve:

- connect a client 
- publish something to a topic
- disconnect
- simulate network failure (disconnect wifi on dev machine)
- eventually get error on parent thread (`MQTT::ProtocolException`, "No Ping Response received...")

Maybe that really is the correct behavior, I dunno, but I would expect pinging to stop once the client disconnects (I'm a noob at MQTT so not sure).

So my solution is just don't do keepalives if the client is disconnected. 