### PR TITLE
added type method for mqtt_proxy.rb

### DIFF
--- a/lib/mqtt/packet.rb
+++ b/lib/mqtt/packet.rb
@@ -128,7 +128,12 @@ module MQTT
         end
       end
     end
-
+    
+    # some mqtt servers fail without this alias
+    def type
+      return type_id
+    end
+    
     # Get the identifer for this packet type
     def type_id
       index = MQTT::PACKET_TYPES.index(self.class)


### PR DESCRIPTION
adding this type method that runs type_id fixes the matt proxy for my mqtt server .
fixes error message - ERROR -- : undefined method `type' for #<MQTT::Packet::Connect:0x007f9d3a9b0dc8>
Did you mean?  type_id