### PR TITLE
Derive Exceptions from StandardError

### DIFF
--- a/lib/mqtt.rb
+++ b/lib/mqtt.rb
@@ -20,7 +20,7 @@ module MQTT
   DEFAULT_SSL_PORT = 8883
 
   # Super-class for other MQTT related exceptions
-  class Exception < ::Exception
+  class Exception < StandardError
   end
 
   # A ProtocolException will be raised if there is a

--- a/spec/mqtt_exception_spec.rb
+++ b/spec/mqtt_exception_spec.rb
@@ -1,0 +1,23 @@
+$:.unshift(File.dirname(__FILE__))
+
+require 'spec_helper'
+require 'mqtt'
+
+describe MQTT do
+
+  describe "mqtt exceptions" do
+    it "should be a ruby standard error" do
+      expect(MQTT::ProtocolException.new).to be_a(StandardError)
+      expect(MQTT::NotConnectedException.new).to be_a(StandardError)
+      expect(MQTT::SN::ProtocolException.new).to be_a(StandardError)
+    end
+
+    it "should be an mqtt error" do
+      expect(MQTT::ProtocolException.new).to be_a(MQTT::Exception)
+      expect(MQTT::NotConnectedException.new).to be_a(MQTT::Exception)
+      expect(MQTT::SN::ProtocolException.new).to be_a(MQTT::Exception)
+    end
+    
+  end
+
+end


### PR DESCRIPTION
Thanks for the nice library.

I think that exceptions should be derived from the ruby `StandardError`. This makes it possible to rescue them in a general rescue block.

It will result in the following code to work as expected:

```ruby
require 'mqtt'
begin
  MQTT::Client.connect('test.mosquitto.org') do |c|
    c.get('test') do |topic,message|
      puts "#{topic}: #{message}"
    end
  end
rescue
  puts "Something went wrong."
end
```