### PR TITLE
Allow to clear the queue of waiting incoming messages

### DIFF
--- a/lib/mqtt/client.rb
+++ b/lib/mqtt/client.rb
@@ -425,6 +425,11 @@ module MQTT
       @read_queue.length
     end
 
+    # Clear the incoming message queue.
+    def clear_queue
+      @read_queue.clear
+    end
+
     # Send a unsubscribe message for one or more topics on the MQTT server
     def unsubscribe(*topics)
       topics = topics.first if topics.is_a?(Enumerable) && topics.count == 1

--- a/spec/mqtt_client_spec.rb
+++ b/spec/mqtt_client_spec.rb
@@ -690,6 +690,15 @@ describe MQTT::Client do
     end
   end
 
+  describe "when calling the 'clear_queue' method" do
+    it "should clear the waiting incoming messages" do
+      inject_packet(:topic => 'topic0', :payload => 'payload0', :qos => 0)
+      expect(client.queue_length).to eq(1)
+      client.clear_queue
+      expect(client.queue_length).to eq(0)
+    end
+  end
+
   describe "when calling the 'get' method" do
     before(:each) do
       client.instance_variable_set('@socket', socket)


### PR DESCRIPTION
We have `queue_empty?` and `queue_length` methods on the `MQTT::Client` class. But we can't clear the queue if needed. This pull request allows to clear the queue.