### PR TITLE
Wrap packet id after 0xffff

### DIFF
--- a/lib/mqtt/client.rb
+++ b/lib/mqtt/client.rb
@@ -545,6 +545,8 @@ module MQTT
 
     def next_packet_id
       @last_packet_id = (@last_packet_id || 0).next
+      @last_packet_id = 1 if @last_packet_id > 0xffff
+      @last_packet_id
     end
 
     # ---- Deprecated attributes and methods  ---- #

--- a/lib/mqtt/packet.rb
+++ b/lib/mqtt/packet.rb
@@ -239,6 +239,7 @@ module MQTT
 
     # Encode a 16-bit unsigned integer and return it
     def encode_short(val)
+      raise 'Value too big for short' if val > 0xffff
       [val.to_i].pack('n')
     end
 

--- a/spec/mqtt_client_spec.rb
+++ b/spec/mqtt_client_spec.rb
@@ -591,6 +591,19 @@ describe MQTT::Client do
       expect(socket.string).to eq("\x32\x10\x00\x05topic\x00\x01payload")
     end
 
+    it "should wrap the packet id after 65535" do
+      0xffff.times do |n|
+        inject_puback(n + 1)
+        client.publish('topic','payload', false, 1)
+      end
+      expect(client.instance_variable_get(:@last_packet_id)).to eq(0xffff)
+
+      socket.string = ""
+      inject_puback(1)
+      client.publish('topic','payload', false, 1)
+      expect(socket.string).to eq("\x32\x10\x00\x05topic\x00\x01payload")
+    end
+
     it "should write a valid PUBLISH packet to the socket with the QoS set to 2" do
       inject_puback(1)
       client.publish('topic','payload', false, 2)

--- a/spec/mqtt_packet_spec.rb
+++ b/spec/mqtt_packet_spec.rb
@@ -49,6 +49,14 @@ describe MQTT::Packet do
       expect(data.encoding.to_s).to eq("ASCII-8BIT")
     end
 
+    it "should raise an error if too big argument for encode_short" do
+      expect {
+        data = packet.send(:encode_short, 0x10000)
+      }.to raise_error(
+        'Value too big for short'
+      )
+    end
+
     it "should provide a add_string method to get a string preceeded by its length" do
       data = packet.send(:encode_string, 'quack')
       expect(data).to eq("\x00\x05quack")


### PR DESCRIPTION
For long running connections, pub acks times out because packet id wraps on 65356, causing timeout errors for ever.
This pr makes the packet id wrap and adds a contract to `MQTT::Packet#encode_short`.