### PR TITLE
Use a queue to wait for Puback packets rather than polling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: ruby
 before_install:
   - gem update bundler
 rvm:
-  - "2.5.1"
+  - "2.6.2"
+  - "2.5.2"
   - "2.4.4"
   - "2.3.4"
-  - "2.1.2"
   - "1.9.3"
-  - "1.8.7"

--- a/lib/mqtt/client.rb
+++ b/lib/mqtt/client.rb
@@ -516,7 +516,7 @@ module MQTT
     else
       # Support older Ruby
       def current_time
-        Time.now.to_i
+        Time.now.to_f
       end
     end
 

--- a/lib/mqtt/client.rb
+++ b/lib/mqtt/client.rb
@@ -459,6 +459,7 @@ module MQTT
     def receive_packet
       # Poll socket - is there data waiting?
       result = IO.select([@socket], [], [], SELECT_TIMEOUT)
+      handle_timeouts
       unless result.nil?
         # Yes - read in the packet
         packet = MQTT::Packet.read(@socket)

--- a/spec/mqtt_client_spec.rb
+++ b/spec/mqtt_client_spec.rb
@@ -620,7 +620,7 @@ describe MQTT::Client do
     else
       # Support older Ruby
       def now
-        Time.now.to_i
+        Time.now.to_f
       end
     end
 


### PR DESCRIPTION
This commit changes the `publish` method to use a queue to wait for
Puback packets rather than polling a hash.  Every time the read loop
gets data or a timeout from `IO.select`, it will send a message to
everyone waiting for a `Puback` packet.  If the we're within the
deadline, then the loop executes again, if we got a packet, we'll return
the packet, and if we're outside the deadline, a `-1` is returned.

This upside is that this patch speeds up the publish method by over
100x.  Here is the benchmark:

```ruby
require "securerandom"
require "mqtt"
require "benchmark/ips"
require "stackprof"

client = MQTT::Client.new(username: 'testuser', password: 'testpasswd', client_id: "client_#{SecureRandom.hex(10)}", host: '127.0.0.1')
client.connect

Benchmark.ips do |x|
  x.report("send message") {
    i = rand(1..10)
    topic = "to/timebox#{i}/cameras"
    msg = "message #{Time.now} for timebox#{i}"
    client.publish(topic, msg, true, 1)
  }
end
```

Before this patch:

```
$ ruby -I lib thing.rb
Warming up --------------------------------------
        send message     8.000  i/100ms
Calculating -------------------------------------
        send message     85.042  (± 4.7%) i/s -    432.000  in   5.089261s
```

After this patch:

```
$ ruby -I lib thing.rb
Warming up --------------------------------------
        send message   915.000  i/100ms
Calculating -------------------------------------
        send message      9.453k (± 4.5%) i/s -     47.580k in   5.043716s
```

The downside is that the timeout isn't exact.  Since `IO.select` times
out every `0.5` seconds (according to the `SELECT_TIMEOUT` constant),
the deadline in the `publish` method could be missed by that amount of
time.

Refs #115