### PR TITLE
Use monotonic clock instead of realtime for keep_alive

### DIFF
--- a/lib/mqtt/client.rb
+++ b/lib/mqtt/client.rb
@@ -159,8 +159,8 @@ module MQTT
       end
 
       # Initialise private instance variables
-      @last_ping_request = Time.now
-      @last_ping_response = Time.now
+      @last_ping_request = current_time
+      @last_ping_response = current_time
       @socket = nil
       @read_queue = Queue.new
       @pubacks = {}
@@ -487,7 +487,7 @@ module MQTT
         # Add to queue
         @read_queue.push(packet)
       elsif packet.class == MQTT::Packet::Pingresp
-        @last_ping_response = Time.now
+        @last_ping_response = current_time
       elsif packet.class == MQTT::Packet::Puback
         @pubacks_semaphore.synchronize do
           @pubacks[packet.id] << packet
@@ -524,11 +524,11 @@ module MQTT
       return unless @keep_alive > 0 && connected?
 
       response_timeout = (@keep_alive * 1.5).ceil
-      if Time.now >= @last_ping_request + @keep_alive
+      if current_time >= @last_ping_request + @keep_alive
         packet = MQTT::Packet::Pingreq.new
         send_packet(packet)
-        @last_ping_request = Time.now
-      elsif Time.now > @last_ping_response + response_timeout
+        @last_ping_request = current_time
+      elsif current_time > @last_ping_response + response_timeout
         raise MQTT::ProtocolException, "No Ping Response received for #{response_timeout} seconds"
       end
     end


### PR DESCRIPTION
Since realtime (`Time.now`) is influenced by changing system time such as NTP, it's not suitable for measuring elapsed time of ping.
