### PR TITLE
Improve `Packet.read_byte` performance

### DIFF
--- a/lib/mqtt/packet.rb
+++ b/lib/mqtt/packet.rb
@@ -219,10 +219,10 @@ module MQTT
 
     # Read and unpack a single byte from a socket
     def self.read_byte(socket)
-      byte = socket.read(1)
+      byte = socket.getbyte
       raise ProtocolException, 'Failed to read byte from socket' if byte.nil?
 
-      byte.unpack('C').first
+      byte
     end
 
     protected


### PR DESCRIPTION
`Packet.read_byte` reads a byte from the socket and returns it.  Before
this commit it would allocate a string and an array, after this commit
it makes 0 allocations.

Here is a benchmark:

```ruby
require "mqtt/packet"

def count_alloc
  x = GC.stat(:total_allocated_objects)
  yield
  GC.stat(:total_allocated_objects) - x
end

File.open(__FILE__) do |f|
  10.times do
    allocations = count_alloc do
      MQTT::Packet.read_byte f
    end

    p ALLOCATIONS: allocations
  end
end
```

On the master branch:

```
$ ruby --disable-gems -I lib -rmqtt/packet test.rb
{:ALLOCATIONS=>11}
{:ALLOCATIONS=>3}
{:ALLOCATIONS=>3}
{:ALLOCATIONS=>3}
{:ALLOCATIONS=>3}
{:ALLOCATIONS=>3}
{:ALLOCATIONS=>3}
{:ALLOCATIONS=>3}
{:ALLOCATIONS=>3}
{:ALLOCATIONS=>3}
```

On this branch:

```
$ ruby --disable-gems -I lib -rmqtt/packet test.rb
{:ALLOCATIONS=>6}
{:ALLOCATIONS=>0}
{:ALLOCATIONS=>0}
{:ALLOCATIONS=>0}
{:ALLOCATIONS=>0}
{:ALLOCATIONS=>0}
{:ALLOCATIONS=>0}
{:ALLOCATIONS=>0}
{:ALLOCATIONS=>0}
{:ALLOCATIONS=>0}
```