### PR TITLE
fix: unescape is now in CGI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 before_install:
   - gem update bundler
 rvm:
+  - "3.0.2"
+  - "2.7.4"
   - "2.6.2"
   - "2.5.2"
   - "2.4.4"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/njh/ruby-mqtt.svg)](https://travis-ci.org/njh/ruby-mqtt)
+[![Build Status](https://travis-ci.com/njh/ruby-mqtt.svg?branch=main)](https://travis-ci.com/njh/ruby-mqtt)
 
 ruby-mqtt
 =========

--- a/lib/mqtt/client.rb
+++ b/lib/mqtt/client.rb
@@ -1,5 +1,6 @@
 autoload :OpenSSL, 'openssl'
 autoload :URI, 'uri'
+autoload :CGI, 'cgi'
 
 # Client class for talking to an MQTT server
 module MQTT
@@ -579,8 +580,8 @@ module MQTT
       {
         :host => uri.host,
         :port => uri.port || nil,
-        :username => uri.user ? URI.unescape(uri.user) : nil,
-        :password => uri.password ? URI.unescape(uri.password) : nil,
+        :username => uri.user ? CGI.unescape(uri.user) : nil,
+        :password => uri.password ? CGI.unescape(uri.password) : nil,
         :ssl => ssl
       }
     end


### PR DESCRIPTION
URI.unescape was deprecated for a long time.
in ruby 3.0 this has been completely removed.
uns CGI.unescape instead.