### PR TITLE
Add Rubocop exemption for the Style/ClassAndModuleChildren rule, so t…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+Style/ClassAndModuleChildren:
+  Enabled: false
 Style/Documentation:
   Enabled: false
 Style/HashSyntax:


### PR DESCRIPTION
…hat the openssl_fix.rb file passes.

As [referenced here](https://github.com/njh/ruby-mqtt/issues/143), this should fix CI which broke in https://github.com/njh/ruby-mqtt/pull/139.

Let me know if you'd prefer to keep this rule and I will update the formatting of `openssl_fix.rb` to comply with the rule, although @lucaong reasoning in that issue convinced me to just disable the rule.


Then ideally you can also merge https://github.com/njh/ruby-mqtt/pull/133 and cut a new release.