### PR TITLE
Add GitHub Actions CI status badge to README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: My workflow
+name: Build
 on: [push, pull_request]
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/njh/ruby-mqtt.svg?branch=main)](https://travis-ci.com/njh/ruby-mqtt)
+[![Build Status](https://github.com/njh/ruby-mqtt/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/njh/ruby-mqtt/actions/workflows/build.yml?query=branch%3Amain)
 
 ruby-mqtt
 =========


### PR DESCRIPTION
Swap the obsolete Travis CI status badge for the new GitHub Actions one.

The new badge looks the same as the old one:

<img width="428" alt="Screenshot 2023-02-16 at 9 41 44 AM" src="https://user-images.githubusercontent.com/225441/219312937-56ce5763-c2a6-498a-9dd5-445b80c817cb.png">
