### PR TITLE
Handle instantaneous and unsolicited PUBACKs

### DIFF
--- a/lib/mqtt/client.rb
+++ b/lib/mqtt/client.rb
@@ -326,14 +326,11 @@ module MQTT
         :payload => payload
       )
 
-      # Send the packet
+      queue = qos.zero? ? nil : wait_for_puback(packet.id)
+
       res = send_packet(packet)
 
-      return if qos.zero?
-
-      queue = Queue.new
-
-      wait_for_puback packet.id, queue
+      return unless queue
 
       deadline = current_time + @ack_timeout
 
@@ -482,9 +479,9 @@ module MQTT
       Thread.current[:parent].raise(exp)
     end
 
-    def wait_for_puback(id, queue)
+    def wait_for_puback(id)
       @pubacks_semaphore.synchronize do
-        @pubacks[id] = queue
+        @pubacks[id] = Queue.new
       end
     end
 
@@ -496,7 +493,7 @@ module MQTT
         @last_ping_response = current_time
       elsif packet.class == MQTT::Packet::Puback
         @pubacks_semaphore.synchronize do
-          @pubacks[packet.id] << packet
+          @pubacks[packet.id] << packet if @pubacks[packet.id]
         end
       end
       # Ignore all other packets


### PR DESCRIPTION
Prior to this commit, it was possible to crash the read thread by sending a PUBACK with an unexpected ID, e.g. an ID the client had not used before, or had already deleted the queue for. These packages will now simple be ignored.

Furthermore, with QoS 1 or 2, the PUBACK queue for a package was only created _after_ the package had already been published. If the PUBACK arrived within this tiny gap, the read thread would crash. We fix this by creating the queue before starting to publish.