### PR TITLE
Prevent deadlock due to system call error

### DIFF
--- a/lib/mqtt/client.rb
+++ b/lib/mqtt/client.rb
@@ -473,7 +473,7 @@ module MQTT
       end
       keep_alive!
     # Pass exceptions up to parent thread
-    rescue Exception => exp
+    rescue ::Exception => exp
       unless @socket.nil?
         @socket.close
         @socket = nil


### PR DESCRIPTION
The MQTT client runs in the main thread which consumes incoming MQTT messages from a `Thread::Queue` called `@read_queue`. This queue is fed by the `@read_thread`, a child thread which reads from a socket in an infinite loop.

We noticed that our application stopped processing incoming MQTT messages, but did not seem to exit or throw an exception either. Upon inspecting the logs, we saw that the `@read_thread` had crashed due to an unhandled `Errno::ECONNRESET` while reading from the socket. This had the consuming thread then sleep forever while waiting for new meassages on the `@read_queue`.

It turned out that the `MQTT::Client#receive_packet` method had appropriate error handling in place

```ruby
def receive_packet
  # ...
rescue Exception
  # ...
end
```

but this did not rescue `Errno::ECONNRESET` even though `Exception` is at the top of the hierarchy of
[Ruby's built-in exception classes][builtin-exceptions].

The root cause was that the library also defines a class `MQTT::Exception` and in the context of `#receive_packet` the constant `Exception` refers only to `MQTT::Exception` (which does not cover `Errno::ECONNRESET`) where it actually should rescue any subclass of `::Exception`.

[builtin-exceptions]: https://docs.ruby-lang.org/en/3.2/Exception.html#class-Exception-label-Built-In+Exception+Classes