### PR TITLE
It is now possible to specify a timeout when opening a TCPSocket.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ client.ca_file   = path_to('root-ca.pem')
 client.connect()
 ~~~
 
-The default timeout when opening a TCP Socket is 30 seconds. To specify it explicitly, use 'connect_timeout => 15'.
+The default timeout when opening a TCP Socket is 30 seconds. To specify it explicitly, use 'connect_timeout =>':
 
 ~~~ ruby
 client = MQTT::Client.connect(

--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ client.ca_file   = path_to('root-ca.pem')
 client.connect()
 ~~~
 
+The default timeout when opening a TCP Socket is 30 seconds. To specify it explicitly, use 'connect_timeout => 15'.
+
+~~~ ruby
+client = MQTT::Client.connect(
+  :host => 'myserver.example.com',
+  :connect_timeout => 15
+)
+~~~
+
 The connection can either be made without the use of a block:
 
 ~~~ ruby

--- a/lib/mqtt/client.rb
+++ b/lib/mqtt/client.rb
@@ -243,17 +243,7 @@ module MQTT
 
       unless connected?
         # Create network socket
-        tcp_socket = if RUBY_VERSION.to_f >= 3.0
-                       TCPSocket.new(@host, @port, connect_timeout: @connect_timeout)
-                     else
-                      begin
-                        Timeout.timeout(@connect_timeout) do
-                          TCPSocket.new(@host, @port)
-                        end
-                      rescue Timeout::Error
-                        raise Errno::ETIMEDOUT.new("Connection timed out for \"#{@host}\" port #{@port}")
-                      end
-                    end
+        tcp_socket = open_tcp_socket
 
         if @ssl
           # Set the protocol version
@@ -614,6 +604,20 @@ module MQTT
       @last_packet_id
     end
 
+    def open_tcp_socket
+      if RUBY_VERSION.to_f >= 3.0
+        return TCPSocket.new(@host, @port, connect_timeout: @connect_timeout)
+      else
+       begin
+         Timeout.timeout(@connect_timeout) do
+           return TCPSocket.new(@host, @port)
+         end
+       rescue Timeout::Error
+         raise Errno::ETIMEDOUT.new("Connection timed out for \"#{@host}\" port #{@port}")
+       end
+     end
+    end
+
     # ---- Deprecated attributes and methods  ---- #
     public
 
@@ -636,5 +640,6 @@ module MQTT
     def remote_port=(args)
       self.port = args
     end
+
   end
 end

--- a/lib/mqtt/client.rb
+++ b/lib/mqtt/client.rb
@@ -605,17 +605,15 @@ module MQTT
     end
 
     def open_tcp_socket
-      if RUBY_VERSION.to_f >= 3.0
-        return TCPSocket.new(@host, @port, connect_timeout: @connect_timeout)
-      else
-       begin
-         Timeout.timeout(@connect_timeout) do
-           return TCPSocket.new(@host, @port)
-         end
-       rescue Timeout::Error
-         raise Errno::ETIMEDOUT.new("Connection timed out for \"#{@host}\" port #{@port}")
-       end
-     end
+      return TCPSocket.new @host, @port, connect_timeout: @connect_timeout if RUBY_VERSION.to_f >= 3.0
+
+      begin
+        Timeout.timeout(@connect_timeout) do
+          return TCPSocket.new(@host, @port)
+        end
+      rescue Timeout::Error
+        raise Errno::ETIMEDOUT, "Connection timed out for \"#{@host}\" port #{@port}"
+      end
     end
 
     # ---- Deprecated attributes and methods  ---- #
@@ -640,6 +638,5 @@ module MQTT
     def remote_port=(args)
       self.port = args
     end
-
   end
 end

--- a/lib/mqtt/client.rb
+++ b/lib/mqtt/client.rb
@@ -612,6 +612,7 @@ module MQTT
           return TCPSocket.new(@host, @port)
         end
       rescue Timeout::Error
+        raise IO::TimeoutError, "Connection timed out for \"#{@host}\" port #{@port}" if defined? IO::TimeoutError
         raise Errno::ETIMEDOUT, "Connection timed out for \"#{@host}\" port #{@port}"
       end
     end

--- a/spec/mqtt_client_spec.rb
+++ b/spec/mqtt_client_spec.rb
@@ -655,6 +655,19 @@ describe MQTT::Client do
       client.instance_variable_set('@socket', socket)
     end
 
+    it "should respect connect_timeout" do
+      client = MQTT::Client.new(:host => '198.51.100.1', :connect_timeout => 0.1)
+      expect {
+        client.connect
+      }.to raise_error( 
+        if defined? IO::TimeoutError
+          IO::TimeoutError
+        else
+          Errno::ETIMEDOUT
+        end
+      )
+    end
+
     it "should respect timeouts" do
       require "socket"
       rd, wr = UNIXSocket.pair


### PR DESCRIPTION
By specifying as follows, you can now specify the timeout time in seconds when MQTTClient opens a TCPSocket.

~~~ ruby
client = MQTT::Client.connect(
  :host => 'myserver.example.com',
  :connect_timeout => 15
)
~~~

The default timeout period is 30 seconds.