### PR TITLE
Add `logger` dependency

### DIFF
--- a/mqtt.gemspec
+++ b/mqtt.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |gem|
   gem.executables   = %w()
   gem.require_paths = %w(lib)
 
+  gem.add_dependency 'logger'
+
   if Gem.ruby_version > Gem::Version.new('3.0')
     gem.add_development_dependency 'bundler',  '>= 1.11.2'
     gem.add_development_dependency 'rake',     '>= 10.2.2'


### PR DESCRIPTION
The `logger` gem will not be bundled with future Ruby versions. https://github.com/ruby/ruby/blob/master/doc/standard_library.md

Noticed this warning when using the gem:

    /Users/dentarg/.arm64_rubies/3.4.3/lib/ruby/gems/3.4.0/gems/mqtt-0.6.0/lib/mqtt.rb:3:
    warning: logger was loaded from the standard library, but will no
    longer be part of the default gems starting from Ruby 3.5.0.  You
    can add logger to your Gemfile or gemspec to silence this warning.

This change ensures the gem keep working with Ruby 3.5+.