### PR TITLE
Add Ruby 4, truffle ruby and jruby to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '3.5']
+        ruby: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0', 'jruby', 'truffleruby']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0', 'jruby', 'truffleruby']
+        ruby: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0', 'jruby-10.1.0', 'truffleruby-33']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/spec/fake_server.rb
+++ b/spec/fake_server.rb
@@ -34,7 +34,7 @@ class MQTT::FakeServer
   #
   # If no port is given, bind to a random port number
   # If no bind address is given, bind to localhost
-  def initialize(port=nil, bind_address='127.0.0.1')
+  def initialize(port=0, bind_address='127.0.0.1')
     @port = port
     @address = bind_address
     @pings_received = 0


### PR DESCRIPTION
It would be nice to be sure that mqtt works with high performance runtimes like jruby and truffleruby. If there are any test failures I’ll look at fixing those up.

I’ve also replaced Ruby 3.5 with Ruby 4.0 as Ruby 3.5 was renamed to 4.0