### PR TITLE
Added an option to wait for suback on subscribe

### DIFF
--- a/lib/mqtt/client.rb
+++ b/lib/mqtt/client.rb
@@ -38,6 +38,9 @@ module MQTT
     # Number of seconds to wait for acknowledgement packets (default is 5 seconds)
     attr_accessor :ack_timeout
 
+    # Block until subscriptions are successful and fail if not (default is false).
+    attr_accessor :verify_subscription
+
     # Number of seconds to connect to the server (default is 90 seconds)
     attr_accessor :connect_timeout
 
@@ -74,6 +77,7 @@ module MQTT
       :clean_session => true,
       :client_id => nil,
       :ack_timeout => 5,
+      :verify_subscription => false,
       :connect_timeout => 30,
       :username => nil,
       :password => nil,
@@ -176,10 +180,10 @@ module MQTT
       @last_ping_response = current_time
       @socket = nil
       @read_queue = Queue.new
-      @pubacks = {}
+      @pending_acks = {}
       @read_thread = nil
       @write_semaphore = Mutex.new
-      @pubacks_semaphore = Mutex.new
+      @pending_acks_semaphore = Mutex.new
     end
 
     # Get the OpenSSL context, that is used if SSL/TLS is enabled
@@ -335,30 +339,35 @@ module MQTT
         :payload => payload
       )
 
-      queue = qos.zero? ? nil : wait_for_puback(packet.id)
+      queue = qos.zero? ? nil : wait_for_ack(packet.id)
 
       res = send_packet(packet)
 
       return unless queue
 
-      deadline = current_time + @ack_timeout
+      case await_ack(packet.id, queue)
+      when :timeout, :close
+        -1
+      else
+        res
+      end
+    end
 
+    def await_ack(id, queue)
+      deadline = current_time + @ack_timeout
       loop do
         response = queue.pop
         case response
         when :read_timeout
-          return -1 if current_time > deadline
+          return :timeout if current_time > deadline
         when :close
-          return -1
+          return :close
         else
-          @pubacks_semaphore.synchronize do
-            @pubacks.delete packet.id
-          end
-          break
+          return response
         end
       end
-
-      res
+    ensure
+      @pending_acks_semaphore.synchronize { @pending_acks.delete id }
     end
 
     # Send a subscribe message for one or more topics on the MQTT server.
@@ -366,6 +375,9 @@ module MQTT
     # * String: subscribe to one topic with QoS 0
     # * Array: subscribe to multiple topics with QoS 0
     # * Hash: subscribe to multiple topics where the key is the topic and the value is the QoS level
+    #
+    # If {#verify_subscription} is set on the client, this method blocks until a
+    # SUBACK is received.
     #
     # For example:
     #   client.subscribe( 'a/b' )
@@ -378,7 +390,22 @@ module MQTT
         :id => next_packet_id,
         :topics => topics
       )
-      send_packet(packet)
+      queue = @verify_subscription ? wait_for_ack(packet.id) : nil
+      res = send_packet(packet)
+      return res unless queue
+
+      case (response = await_ack(packet.id, queue))
+      when :timeout
+        raise MQTT::ProtocolException, 'Timed out waiting for SUBACK'
+      when :close
+        raise MQTT::ProtocolException, 'Connection closed waiting for SUBACK'
+      else
+        rejected_topics = packet.topic_failures(response)
+        if rejected_topics.any?
+          raise MQTT::ProtocolException, "Subscription rejected by broker for topics: #{rejected_topics.inspect}"
+        end
+        res
+      end
     end
 
     # Return the next message received from the MQTT server.
@@ -488,9 +515,9 @@ module MQTT
       Thread.current[:parent].raise(exp)
     end
 
-    def wait_for_puback(id)
-      @pubacks_semaphore.synchronize do
-        @pubacks[id] = Queue.new
+    def wait_for_ack(id)
+      @pending_acks_semaphore.synchronize do
+        @pending_acks[id] = Queue.new
       end
     end
 
@@ -500,9 +527,9 @@ module MQTT
         @read_queue.push(packet)
       elsif packet.class == MQTT::Packet::Pingresp
         @last_ping_response = current_time
-      elsif packet.class == MQTT::Packet::Puback
-        @pubacks_semaphore.synchronize do
-          @pubacks[packet.id] << packet if @pubacks[packet.id]
+      elsif [MQTT::Packet::Puback, MQTT::Packet::Suback].include?(packet.class)
+        @pending_acks_semaphore.synchronize do
+          @pending_acks[packet.id] << packet if @pending_acks[packet.id]
         end
       end
       # Ignore all other packets
@@ -510,14 +537,14 @@ module MQTT
     end
 
     def handle_timeouts
-      @pubacks_semaphore.synchronize do
-        @pubacks.each_value { |q| q << :read_timeout }
+      @pending_acks_semaphore.synchronize do
+        @pending_acks.each_value { |q| q << :read_timeout }
       end
     end
 
     def handle_close
-      @pubacks_semaphore.synchronize do
-        @pubacks.each_value { |q| q << :close }
+      @pending_acks_semaphore.synchronize do
+        @pending_acks.each_value { |q| q << :close }
       end
     end
 

--- a/lib/mqtt/packet.rb
+++ b/lib/mqtt/packet.rb
@@ -747,6 +747,11 @@ module MQTT
         super(ATTR_DEFAULTS.merge(args))
       end
 
+      # Returns the names of topics whose subscription was rejected, given a Suback response
+      def topic_failures(suback)
+        topics.zip(suback.failures).select { |_, failed| failed }.map { |topic, _| topic.first }
+      end
+
       # Set one or more topic filters for the Subscribe packet
       # The topics parameter should be one of the following:
       # * String: subscribe to one topic with QoS 0
@@ -829,6 +834,9 @@ module MQTT
       # An array of return codes, ordered by the topics that were subscribed to
       attr_accessor :return_codes
 
+      # Return codes greater than or equal to this value indicate a failure
+      FAILURE_RETURN_CODE = 0x80
+
       # Default attribute values
       ATTR_DEFAULTS = {
         :return_codes => []
@@ -866,6 +874,11 @@ module MQTT
         super(buffer)
         @id = shift_short(buffer)
         @return_codes << shift_byte(buffer) while buffer.bytesize > 0
+      end
+
+      # Returns an array of booleans (parallel to return_codes) indicating whether each subscription was rejected
+      def failures
+        return_codes.map { |rc| rc >= FAILURE_RETURN_CODE }
       end
 
       # Returns a human readable string, summarising the properties of the packet

--- a/spec/mqtt_client_spec.rb
+++ b/spec/mqtt_client_spec.rb
@@ -631,25 +631,25 @@ describe MQTT::Client do
   end
 
   describe "when calling the 'publish' method" do
-    class ClientWithPubackInjection < MQTT::Client
-      def initialize
-        super(:host => 'localhost')
-        @injected_pubacks = {}
+    class ClientWithAckInjection < MQTT::Client
+      def initialize(**opts)
+        super(:host => 'localhost', **opts)
+        @injected_acks = {}
       end
 
-      def inject_puback(packet)
-        @injected_pubacks[packet.id] = packet
+      def inject_ack(packet)
+        @injected_acks[packet.id] = packet
       end
 
-      def wait_for_puback(id)
-        packet = @injected_pubacks.fetch(id) {
+      def wait_for_ack(id)
+        packet = @injected_acks.fetch(id) {
           return super
         }
         Queue.new << packet
       end
     end
 
-    let(:client) { ClientWithPubackInjection.new }
+    let(:client) { ClientWithAckInjection.new }
 
     before(:each) do
       client.instance_variable_set('@socket', socket)
@@ -659,7 +659,7 @@ describe MQTT::Client do
       client = MQTT::Client.new(:host => '198.51.100.1', :connect_timeout => 0.1)
       expect {
         client.connect
-      }.to raise_error( 
+      }.to raise_error(
         if defined? IO::TimeoutError
           IO::TimeoutError
         else
@@ -797,6 +797,64 @@ describe MQTT::Client do
     it "should write a valid SUBSCRIBE packet to the socket if given a two topic Strings with QoS in a Hash" do
       client.subscribe('a/b' => 0,'c/d' => 1)
       expect(socket.string).to eq("\x82\x0e\x00\x01\x00\x03a/b\x00\x00\x03c/d\x01")
+    end
+  end
+
+  describe "when verify_subscription is true" do
+    let(:client) { ClientWithAckInjection.new(:verify_subscription => true) }
+
+    before(:each) do
+      client.instance_variable_set('@socket', socket)
+    end
+
+    it "should write a valid SUBSCRIBE packet to the socket" do
+      inject_suback(1)
+      client.subscribe('a/b')
+      expect(socket.string).to eq("\x82\x08\x00\x01\x00\x03a/b\x00")
+    end
+
+    it "should return the same value as send_packet on success" do
+      inject_suback(1)
+      subscribe_packet = "\x82\x08\x00\x01\x00\x03a/b\x00"
+      expect(client.subscribe('a/b')).to eq(subscribe_packet.bytesize)
+    end
+
+    it "should raise MQTT::ProtocolException if the broker rejects with return code 0x80" do
+      inject_suback(1, [0x80])
+      expect { client.subscribe('a/b') }.to raise_error(
+        MQTT::ProtocolException,
+        'Subscription rejected by broker for topics: ["a/b"]'
+      )
+    end
+
+    it "should mention only the rejected topic when one is granted and another rejected" do
+      inject_suback(1, [0x00, 0x80])
+      expect { client.subscribe(['a/b', 0], ['c/d', 1]) }.to raise_error(
+        MQTT::ProtocolException,
+        'Subscription rejected by broker for topics: ["c/d"]'
+      )
+    end
+
+    it "should raise on ack_timeout if no SUBACK arrives" do
+      require "socket"
+      rd, wr = UNIXSocket.pair
+      client = MQTT::Client.new(:host => 'localhost', :ack_timeout => 1.0, :verify_subscription => true)
+      client.instance_variable_set('@socket', rd)
+      t = Thread.new {
+        Thread.current[:parent] = Thread.main
+        loop do
+          client.send :receive_packet
+        end
+      }
+      start = now
+      expect { client.subscribe('topic') }.to raise_error(MQTT::ProtocolException, 'Timed out waiting for SUBACK')
+      elapsed = now - start
+      t.kill
+      expect(elapsed).to be_within(0.1).of(1.0)
+    end
+
+    it "does not crash when receiving a SUBACK for a packet it never sent" do
+      expect { client.send(:handle_packet, MQTT::Packet::Suback.new(:id => 666, :return_codes => [0])) }.to_not raise_error
     end
   end
 
@@ -1112,7 +1170,12 @@ describe MQTT::Client do
 
   def inject_puback(packet_id)
     packet = MQTT::Packet::Puback.new(:id => packet_id)
-    client.inject_puback packet
+    client.inject_ack packet
+  end
+
+  def inject_suback(packet_id, return_codes = [0])
+    packet = MQTT::Packet::Suback.new(:id => packet_id, :return_codes => return_codes)
+    client.inject_ack packet
   end
 
 end

--- a/spec/mqtt_packet_spec.rb
+++ b/spec/mqtt_packet_spec.rb
@@ -1560,6 +1560,20 @@ describe MQTT::Packet::Subscribe do
       expect(packet.inspect).to eq("#<MQTT::Packet::Subscribe: 0x00, 'a':1, 'b':0, 'c':2>")
     end
   end
+
+  describe "#topic_failures" do
+    it "should return the names of topics whose subscription was rejected" do
+      subscribe = MQTT::Packet::Subscribe.new(:topics => [['a/b', 0], ['c/d', 1]])
+      suback = MQTT::Packet::Suback.new(:return_codes => [0, 0x80])
+      expect(subscribe.topic_failures(suback)).to eq(['c/d'])
+    end
+
+    it "should be empty when every topic was granted" do
+      subscribe = MQTT::Packet::Subscribe.new(:topics => [['a/b', 0], ['c/d', 1]])
+      suback = MQTT::Packet::Suback.new(:return_codes => [0, 1])
+      expect(subscribe.topic_failures(suback)).to eq([])
+    end
+  end
 end
 
 describe MQTT::Packet::Suback do
@@ -1655,6 +1669,18 @@ describe MQTT::Packet::Suback do
       packet.return_codes = [0,1,0]
       expect(packet.granted_qos).to eq([0,1,0])
       expect(packet.return_codes).to eq([0,1,0])
+    end
+  end
+
+  describe "#failures" do
+    it "should be a parallel array of booleans indicating which return codes were rejected" do
+      packet = MQTT::Packet::Suback.new(:return_codes => [0, 0x80, 1, 0x80])
+      expect(packet.failures).to eq([false, true, false, true])
+    end
+
+    it "should be empty when there are no return codes" do
+      packet = MQTT::Packet::Suback.new(:return_codes => [])
+      expect(packet.failures).to eq([])
     end
   end
 end


### PR DESCRIPTION
Right now if you subscribe to a topic there's no warning if the subscription fails, it just silently continues and if you're waiting for messages to arrive you might never realise (as nothing will ever be delivered).

To prevent this I've added an option to the client to verify subscription, then if no suback is received or there's an issue with the suback then an error is raised. If this option isn't set then nothing should change. I've reused existing code that checked for pubacks to do this.