### PR TITLE
Fix reader thread raising exceptions into wrong thread

### DIFF
--- a/lib/mqtt/client.rb
+++ b/lib/mqtt/client.rb
@@ -435,12 +435,20 @@ module MQTT
         # Loop forever!
         loop do
           packet = @read_queue.pop
+          if packet == :close
+            check_for_exception!
+            raise MQTT::NotConnectedException
+          end
           yield(packet)
           puback_packet(packet) if packet.qos > 0
         end
       else
         # Wait for one packet to be available
         packet = @read_queue.pop
+        if packet == :close
+          check_for_exception!
+          raise MQTT::NotConnectedException
+        end
         puback_packet(packet) if packet.qos > 0
         return packet
       end
@@ -527,6 +535,7 @@ module MQTT
       @pubacks_semaphore.synchronize do
         @pubacks.each_value { |q| q << :close }
       end
+      @read_queue << :close
     end
 
     if Process.const_defined? :CLOCK_MONOTONIC

--- a/lib/mqtt/client.rb
+++ b/lib/mqtt/client.rb
@@ -180,6 +180,8 @@ module MQTT
       @read_thread = nil
       @write_semaphore = Mutex.new
       @pubacks_semaphore = Mutex.new
+      @last_exception = nil
+      @exception_mutex = Mutex.new
     end
 
     # Get the OpenSSL context, that is used if SSL/TLS is enabled
@@ -282,8 +284,8 @@ module MQTT
         receive_connack
 
         # Start packet reading thread
-        @read_thread = Thread.new(Thread.current) do |parent|
-          Thread.current[:parent] = parent
+        @exception_mutex.synchronize { @last_exception = nil }
+        @read_thread = Thread.new do
           receive_packet while connected?
         end
       end
@@ -305,6 +307,9 @@ module MQTT
       @read_thread.kill if @read_thread && @read_thread.alive?
       @read_thread = nil
 
+      # Clear any stored exception so a reconnect starts clean
+      @exception_mutex.synchronize { @last_exception = nil }
+
       return unless connected?
 
       # Close the socket if it is open
@@ -324,6 +329,7 @@ module MQTT
 
     # Publish a message on a particular topic to the MQTT server.
     def publish(topic, payload = '', retain = false, qos = 0)
+      check_for_exception!
       raise ArgumentError, 'Topic name cannot be nil' if topic.nil?
       raise ArgumentError, 'Topic name cannot be empty' if topic.empty?
 
@@ -374,6 +380,7 @@ module MQTT
     #   client.subscribe( 'a/b' => 0, 'c/d' => 1 )
     #
     def subscribe(*topics)
+      check_for_exception!
       packet = MQTT::Packet::Subscribe.new(
         :id => next_packet_id,
         :topics => topics
@@ -420,6 +427,7 @@ module MQTT
     #   end
     #
     def get_packet(topic = nil)
+      check_for_exception!
       # Subscribe to a topic, if an argument is given
       subscribe(topic) unless topic.nil?
 
@@ -485,7 +493,7 @@ module MQTT
         @socket = nil
         handle_close
       end
-      Thread.current[:parent].raise(exp)
+      @exception_mutex.synchronize { @last_exception = exp }
     end
 
     def wait_for_puback(id)
@@ -575,6 +583,18 @@ module MQTT
       # Only allow one thread to write to socket at a time
       @write_semaphore.synchronize do
         @socket.write(data.to_s)
+      end
+    end
+
+    # Raise any exception stored by the reader thread so the calling thread
+    # receives it, regardless of which thread originally called connect.
+    def check_for_exception!
+      @exception_mutex.synchronize do
+        e = @last_exception
+        if e
+          @last_exception = nil
+          raise e
+        end
       end
     end
 

--- a/spec/mqtt_client_spec.rb
+++ b/spec/mqtt_client_spec.rb
@@ -981,8 +981,6 @@ describe MQTT::Client do
       client.instance_variable_set('@socket', socket)
       allow(IO).to receive(:select).and_return([[socket], [], []])
       @read_queue = client.instance_variable_get('@read_queue')
-      @parent_thread = Thread.current[:parent] = double('Parent Thread')
-      allow(@parent_thread).to receive(:raise)
     end
 
     it "should put PUBLISH messages on to the read queue" do
@@ -1011,18 +1009,18 @@ describe MQTT::Client do
       client.send(:receive_packet)
     end
 
-    it "should pass exceptions up to parent thread" do
+    it "should store MQTT exceptions so the calling thread can raise them" do
       e = MQTT::Exception.new
-      expect(@parent_thread).to receive(:raise).with(e).once
       allow(MQTT::Packet).to receive(:read).and_raise(e)
       client.send(:receive_packet)
+      expect { client.send(:check_for_exception!) }.to raise_error(MQTT::Exception)
     end
 
-    it "should pass a system call error up to parent thread" do
+    it "should store system call errors so the calling thread can raise them" do
       e = Errno::ECONNRESET.new
-      expect(@parent_thread).to receive(:raise).with(e).once
       allow(MQTT::Packet).to receive(:read).and_raise(e)
       client.send(:receive_packet)
+      expect { client.send(:check_for_exception!) }.to raise_error(Errno::ECONNRESET)
     end
 
     it "should update last_ping_response when receiving a Pingresp" do

--- a/spec/mqtt_client_spec.rb
+++ b/spec/mqtt_client_spec.rb
@@ -953,6 +953,27 @@ describe MQTT::Client do
         expect(packets.map{|p| p.payload}).to eq(['payload0', 'payload1'])
       end
     end
+
+    context "when the connection drops while waiting" do
+      it "should raise a stored reader thread exception" do
+        e = MQTT::Exception.new('connection lost')
+        client.instance_variable_set('@last_exception', e)
+        client.instance_variable_get('@read_queue') << :close
+        expect { client.get_packet }.to raise_error(MQTT::Exception, 'connection lost')
+      end
+
+      it "should raise NotConnectedException if there is no stored exception" do
+        client.instance_variable_get('@read_queue') << :close
+        expect { client.get_packet }.to raise_error(MQTT::NotConnectedException)
+      end
+
+      it "should raise a stored exception when using the block form" do
+        e = Errno::ECONNRESET.new
+        client.instance_variable_set('@last_exception', e)
+        client.instance_variable_get('@read_queue') << :close
+        expect { client.get_packet { |_p| } }.to raise_error(Errno::ECONNRESET)
+      end
+    end
   end
 
   describe "when calling the 'unsubscribe' method" do
@@ -1028,6 +1049,20 @@ describe MQTT::Client do
       client.instance_variable_set '@last_ping_response', Time.at(0)
       client.send :receive_packet
       expect(client.last_ping_response).to be_within(1).of now
+    end
+  end
+
+  describe "when calling the 'handle_close' method" do
+    it "should push :close onto the read queue" do
+      client.send(:handle_close)
+      expect(client.instance_variable_get('@read_queue').pop).to eq(:close)
+    end
+
+    it "should notify puback waiters with :close" do
+      queue = Queue.new
+      client.instance_variable_get('@pubacks')[1] = queue
+      client.send(:handle_close)
+      expect(queue.pop).to eq(:close)
     end
   end
 

--- a/spec/zz_client_integration_spec.rb
+++ b/spec/zz_client_integration_spec.rb
@@ -164,8 +164,9 @@ describe "a client talking to a server" do
 
     context "when keep-alive=1" do
       it "the server should have received at least one ping" do
+        connect_and_timeout(1)
         expect {
-          connect_and_timeout(1)
+          @client.publish('test', '')
         }.to raise_error(
           MQTT::ProtocolException,
           'No Ping Response received for 2 seconds'


### PR DESCRIPTION
Closes #169 

Fixes the bug where reader thread exceptions were delivered via `Thread#raise` to
whichever thread called `connect`, rather than the thread actively using the connection.
This made the client unsafe to use with connection pools or in any multi-threaded context.

## What changed

Instead of capturing the connect-caller as a "parent" and using `Thread#raise` to
deliver errors cross-thread, exceptions are now stored on the client instance under
a mutex:

```ruby
@exception_mutex.synchronize { @last_exception = exp }
```

Every public method that uses the socket (`publish`, `subscribe`, `get_packet`) calls
`check_for_exception!` before proceeding. This re-raises the stored exception in
whichever thread is actually doing the work, and clears it atomically so it fires
exactly once.

## Behaviour

- A thread using a broken connection receives the error immediately on its next call
- No exception is ever injected into an unrelated thread
- `disconnect` and `connect` both clear the stored exception, so reconnect is always a clean slate
- If the stored exception is raised and the caller rescues it, subsequent calls raise `MQTT::NotConnectedException` (the normal not-connected path) rather than replaying the stale error

## Tests

The two specs that explicitly wired up `Thread.current[:parent]` and expected
`Thread#raise` to be called have been updated to verify the new behaviour: that the
exception is stored and re-raised by `check_for_exception!` in the calling thread.
